### PR TITLE
Remove global organization setting, and persist organization to children

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,11 @@ criterion.name
 # => "Policy Manual"
 ```
 
-To work with organization-specific evidence (i.e., documents and events), you may set the `Aptible::Gridiron.configuration.organization` variable. For example:
+To work with organization-specific evidence (i.e., documents and events), you may pass `:organization` as a parameter in any initializer. For example:
 
 ```ruby
 organization = Aptible::Auth::Organization.all(token: token).first
-Aptible::Gridiron.configure do |config|
-  config.organization = organization
-end
-
-gridiron = Aptible::Gridiron::Agent.new(token: token)
+gridiron = Aptible::Gridiron::Agent.new(token: token, organization: organization)
 criterion = gridiron.protocols.first.procedures.first.criteria.first
 criterion.documents.count
 # => 1
@@ -64,7 +60,6 @@ document.expires_at
 | Parameter | Description | Default |
 | --------- | ----------- | --------------- |
 | `root_url` | Root URL of the Gridiron server | `ENV['GRIDIRON_ROOT_URL']` or [https://gridiron.aptible.com](https://gridiron.aptible.com) |
-| `organization` | `Aptible::Auth::Organization` instance to be used for all documents/events | `nil` |
 
 To point the client at a different server (e.g., during development), add the following to your application's initializers (or set the `GRIDIRON_ROOT_URL` environment variable):
 

--- a/lib/aptible/gridiron.rb
+++ b/lib/aptible/gridiron.rb
@@ -13,9 +13,6 @@ module Aptible
       has :root_url,
           classes: [String],
           default: ENV['GRIDIRON_ROOT_URL'] || 'https://gridiron.aptible.com'
-      has :organization,
-          classes: [Aptible::Auth::Organization, NilClass],
-          default: nil
     end
   end
 end

--- a/lib/aptible/gridiron/criterion.rb
+++ b/lib/aptible/gridiron/criterion.rb
@@ -11,6 +11,26 @@ module Aptible
       field :evidence_type
       field :scope
       field :default_expiry
+
+      def documents
+        evidence_type == 'document' ? super : []
+      end
+
+      def events
+        evidence_type == 'event' ? super : []
+      end
+
+      def status
+        green? ? 'green' : 'red'
+      end
+
+      # TODO: Move to Gridiron, or fix logic
+      def green?
+        return true if evidence_type == 'event'
+
+        return false unless documents.first
+        documents.first.expires_at > Time.now
+      end
     end
   end
 end

--- a/lib/aptible/gridiron/evidence.rb
+++ b/lib/aptible/gridiron/evidence.rb
@@ -5,6 +5,7 @@ module Aptible
 
       field :id
       field :data
+      field :created_at, type: Time
 
       def organization
         auth = Aptible::Auth::Organization.new(token: token, headers: headers)

--- a/lib/aptible/gridiron/resource.rb
+++ b/lib/aptible/gridiron/resource.rb
@@ -3,21 +3,24 @@ require 'aptible/resource'
 module Aptible
   module Gridiron
     class Resource < Aptible::Resource::Base
-      def self.normalize_params(params = {})
-        # TODO: Figure out a more natural solution than this monkey patch
-        if (organization = Aptible::Gridiron.configuration.organization)
-          params.merge!(organization: organization.href)
-        end
-
-        super(params)
+      def outgoing_uri_filter(params)
+        params.merge!(organization: organization) if organization
       end
 
-      def outgoing_uri_filter(params)
-        if (organization = Aptible::Gridiron.configuration.organization)
-          params.merge!(organization: organization.href)
+      def organization
+        # TODO: Is there another way to persist organization across children
+        headers['X-Aptible-Organization']
+      end
+
+      def initialize(options = {})
+        if options.is_a?(Hash) && options[:organization]
+          options[:headers] ||= {}
+          options[:headers].merge!(
+            'X-Aptible-Organization' => options[:organization].href
+          )
         end
 
-        params
+        super(options)
       end
 
       def namespace

--- a/lib/aptible/gridiron/version.rb
+++ b/lib/aptible/gridiron/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Gridiron
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Setting a global `:organization` causes a lot of problems, since it can persist across requests. This moves the setting onto the initial instance of a Gridiron resource, and passes the setting along to all its children.
